### PR TITLE
Removed trailing space from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "raw-loader": "0.5.1",
     "@ngtools/webpack": "1.4.2",
     "google-closure-compiler": "20170521.0.0",
-    "core-js-builder ": "2.4.1"
+    "core-js-builder": "2.4.1"
   }
 }


### PR DESCRIPTION
It just failed my npm install attempt:

`npm ERR! Invalid package name "core-js-builder ": name cannot contain leading or trailing spaces; name can only contain URL-friendly characters`
